### PR TITLE
fix npe

### DIFF
--- a/src/main/java/com/potionbar/PotionBarPlugin.java
+++ b/src/main/java/com/potionbar/PotionBarPlugin.java
@@ -52,7 +52,7 @@ public class PotionBarPlugin extends Plugin  {
 		public Widget backgroundBar;
 	}
 
-	private List<PotionPanel> potionPanels;
+	private List<PotionPanel> potionPanels = new ArrayList<>();
 
 	@Provides
 	PotionBarConfig provideConfig(ConfigManager configManager) {
@@ -89,7 +89,7 @@ public class PotionBarPlugin extends Plugin  {
 	}
 
 	private void createProgressBars() {
-		potionPanels = new ArrayList<>();
+		potionPanels.clear();
 
 		Widget w = client.getWidget(ComponentID.BANK_POTIONSTORE_CONTENT);
 		Widget[] children = w.getDynamicChildren();


### PR DESCRIPTION
fixes an npe that's throwing on every client tick after login. presumably `ScriptID.POTIONSTORE_WITHDRAW_DOSES` is running on login for some reason. After that, every update fails so it just npes forever. Having the empty list on startup instead of null is not really any different.